### PR TITLE
change ipv4 address of srl3:ethernet-1/1

### DIFF
--- a/labs/mpls-ldp/srl3.cfg
+++ b/labs/mpls-ldp/srl3.cfg
@@ -3,7 +3,7 @@ set / interface ethernet-1/1 admin-state enable
 set / interface ethernet-1/1 subinterface 0
 set / interface ethernet-1/1 subinterface 0 admin-state enable
 set / interface ethernet-1/1 subinterface 0 ipv4
-set / interface ethernet-1/1 subinterface 0 ipv4 address 10.2.3.3/30
+set / interface ethernet-1/1 subinterface 0 ipv4 address 10.2.3.2/30
 
 
 


### PR DESCRIPTION
I find it a little odd to use the broadcast address (10.2.3.3/30) for a point-to-point interface of the node srl3. 