### PR TITLE
Fix trailing space with shell annotations and `/` char

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -41,10 +41,10 @@ Let's explore the different ways you can launch SR Linux container.
 
 `docker` CLI offers a quick way to run a standalone SR Linux container:
 
-```shell
+```bash
 sudo docker run -t -d --rm --privileged \
   -u 0:0 \
-  -v srl23-7-1.json:/etc/opt/srlinux/config.json \#(1)!
+  -v srl23-7-1.json:/etc/opt/srlinux/config.json \ #(1)!
   --name srlinux ghcr.io/nokia/srlinux:23.7.1 \
   sudo bash /opt/srlinux/bin/sr_linux
 ```

--- a/docs/javascripts/sh-annotation.js
+++ b/docs/javascripts/sh-annotation.js
@@ -1,0 +1,10 @@
+// this script is used to remove extra leading space when annotating shell code blocks ending with `\`
+// character. See https://github.com/squidfunk/mkdocs-material/issues/3846 for more info.
+document$.subscribe(() => {
+    const tags = document.querySelectorAll("code .se")
+    tags.forEach(tag => {
+        if (tag.innerText.startsWith("\\")) {
+            tag.innerText = "\\"
+        }
+    })
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -310,3 +310,6 @@ extra_css:
   - stylesheets/nokia-fonts.css
   - stylesheets/diagrams.css
   - stylesheets/animations.css
+
+extra_javascript:
+  - javascripts/sh-annotation.js


### PR DESCRIPTION
Annotations added to the end of the sh/bash string ending with `\` char would lead to the space being preserved that would render the command invalid.

This fixes the behavior as suggested here https://github.com/squidfunk/mkdocs-material/issues/3846