### PR TITLE
Clarify ops ordering based on ansible 0.6.0

### DIFF
--- a/docs/ansible/collection/config.md
+++ b/docs/ansible/collection/config.md
@@ -114,9 +114,9 @@ In the example below, the module is stuffed with multiple updates, replaces and 
 
 Config module uses JSON-RPC interface of SR Linux, and in particular, its [`Set` method](../../tutorials/programmability/json-rpc/basics.md#set). Upon receiving the Set method, SR Linux opens a private named candidate configuration and applies the operations in the  following order:
 
-1. updates
+1. deletes
 2. replaces
-3. deletes
+3. updates
 
 Note, that the operations that are part of the module's task are not committed independently, they are applied strictly together in the "all or nothing" fashion. When we say that the operations are applied in that order, we mean that changes get applied to the candidate configuration in that order. No commit happens just yet.
 

--- a/docs/blog/posts/2023/ansible-collection.md
+++ b/docs/blog/posts/2023/ansible-collection.md
@@ -18,7 +18,7 @@ In this blog post, we would like to share some details about our design decision
 
 ## Deficiencies of the URI module
 
-The URI module is a great tool for making REST API calls. It is very flexible, generic and can be used to make any type of HTTP/RESTAPI calls. However, its generic nature can also be seen as a drawback.
+The URI module is a great tool for making REST API calls. It is very flexible, generic and can be used to make any type of HTTP/REST API calls. However, its generic nature can also be seen as a drawback.
 
 ### Verbosity
 


### PR DESCRIPTION
In srlinux-ansible 0.6.0 I changed the order of ops to be delete->replace->update that is better than the previous delete->update->replace